### PR TITLE
Display output for running server

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,7 +6,7 @@ import { ServersViewTreeDataProvider } from './serverExplorer';
 //import { LanguageClient, LanguageClientOptions, RevealOutputChannelOn, StreamInfo} from 'vscode-languageclient';
 import * as net from 'net';
 import * as rpc from 'vscode-jsonrpc';
-import { ServerAddedNotification, ServerStateChangeNotification, StartServerAsyncNotification, StopServerAsyncNotification, ServerRemovedNotification, DeleteServerNotification } from './protocol';
+import { ServerAddedNotification, ServerStateChangeNotification, StartServerAsyncNotification, StopServerAsyncNotification, ServerRemovedNotification, DeleteServerNotification, ServerProcessOutputAppendedNotification } from './protocol';
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
@@ -52,8 +52,12 @@ export function activate(context: vscode.ExtensionContext) {
 
         connection.onNotification(ServerStateChangeNotification.type, event => {
             serversData.updateServer(event);
-            console.log(event);
         });
+
+        connection.onNotification(ServerProcessOutputAppendedNotification.type, event => {
+            serversData.addServerOutput(event);
+        });
+
 
 
         const serversData = new ServersViewTreeDataProvider(connection);

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -161,3 +161,7 @@ export namespace StopServerAsyncNotification {
 export namespace ServerStateChangeNotification {
     export const type = new NotificationType<ServerStateChange, void>('client/serverStateChanged');
 }
+
+export namespace ServerProcessOutputAppendedNotification {
+    export const type = new NotificationType<ServerProcessOutput, void>('client/serverProcessOutputAppended');
+}


### PR DESCRIPTION
Output for server appears in output view as "Server: ${server.name}". 
When server starts, running or stopping all messages from server are redirected to server specific output channel.
When server deleted, its output channel is deleted as well.
If server started second time, output channel is getting cleaned after extension gets status change 'starting' for server.