### PR TITLE
Improve servers view context menu presentation based on server state

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,22 +56,37 @@
             }],
             "view/item/context": [{
                     "command": "server.start",
-                    "when": "view == servers && viewItem == 'server'",
+                    "when": "view == servers && viewItem == 'Stopped'",
                     "group": "a@1"
                 },
                 {
                     "command": "server.stop",
-                    "when": "view == servers && viewItem == 'server'",
+                    "when": "view == servers && viewItem == 'Started'",
                     "group": "a@2"
                 },
                 {
                     "command": "server.remove",
-                    "when": "view == servers && viewItem == 'server'",
+                    "when": "view == servers && viewItem == 'Stopped'",
                     "group": "b"
                 },
                 {
                     "command": "server.output",
-                    "when": "view == servers && viewItem == 'server'",
+                    "when": "view == servers && viewItem == 'Started'",
+                    "group": "c"
+                },
+                {
+                    "command": "server.output",
+                    "when": "view == servers && viewItem == 'Stopped'",
+                    "group": "c"
+                },
+                {
+                    "command": "server.output",
+                    "when": "view == servers && viewItem == 'Starting'",
+                    "group": "c"
+                },
+                {
+                    "command": "server.output",
+                    "when": "view == servers && viewItem == 'Stopping'",
                     "group": "c"
                 }
             ]

--- a/src/serverExplorer.ts
+++ b/src/serverExplorer.ts
@@ -124,8 +124,8 @@ export class ServersViewTreeDataProvider implements TreeDataProvider<ServerHandl
 
     getTreeItem(server: ServerHandle): TreeItem | Thenable<TreeItem> {
         var status:number = this.serverStatus.get(server.id);
-        var item:TreeItem = new TreeItem(server.id + '(' + this.serverStatusEnum.get(status) + ')');
-        item.contextValue = 'server';
+        var item:TreeItem = new TreeItem(server.id + ' (' + this.serverStatusEnum.get(status) + ')');
+        item.contextValue =  this.serverStatusEnum.get(status);
         return item;
     }
 


### PR DESCRIPTION
VSCode has no API to disable/enable context menu items for treeview items. As a workaround for that it is possible generate menu based on treeview item state and show only available context menu items for specific state.

Server state diagram looks like 

![image](https://user-images.githubusercontent.com/620330/41027392-c61a988a-692b-11e8-8c09-ec2eca4b6148.png)

This PR updates contribution point declarations to show only available context menu items for server view tree items based on its state.